### PR TITLE
Fix icon spacing so empty space with underline doesn't display

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -144,6 +144,7 @@ article {
 	width: $gutterY;
 	height: $gutterX;
 	background-size: $gutterX;
+	margin-right: $gutterX / 2;
 }
 .icon-spec {
 	background-image: url(images/html5.png);

--- a/src/tpl/index.html
+++ b/src/tpl/index.html
@@ -60,27 +60,22 @@
               {{#if mdn_url}}
                 <li>
                   <a target="_blank" href="{{mdn_url}}" title="Documentation on Mozilla Developer Network (MDN)">
-                    <i class="icon icon-mdn"></i>
-                    Docs
+                    <i aria-hidden="true" class="icon icon-mdn"></i>Docs
                   </a>
                 </li>
               {{/if}}
               {{#if spec_url}}
                 <li>
                   <a target="_blank" href="{{spec_url}}" title="{{alt spec_status 'spec' 'long'}}">
-                    <i class="icon icon-spec"></i>
-                    {{alt spec_status 'spec' 'short'}}
+                    <i aria-hidden="true" class="icon icon-spec"></i>{{alt spec_status 'spec' 'short'}}
                   </a>
                 </li>
               {{/if}}
               {{#if bugzilla}}
                 <li>
                   <a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bugzilla}}" title="Implementation bug at bugzilla.mozilla.org">
-                    <i class="icon icon-bugzilla"></i>
-                    {{#if_eq firefox_status "shipped"}}
-                      Fixed
-                    {{else}}
-                      {{bugzilla_resolved_count}}/{{bugzilla_dependant_count}} Resolved
+                    <i aria-hidden="true" class="icon icon-bugzilla"></i>{{#if_eq firefox_status "shipped"}}Fixed
+                    {{else}}{{bugzilla_resolved_count}}/{{bugzilla_dependant_count}} Resolved
                     {{/if_eq}}
                   </a>
                 </li>


### PR DESCRIPTION
The space between the icon and link text was being underlined and that bugged me for some reason.  Also adding attributes so screen readers don't read out the icons.