### PR TITLE
Ensure display always takes up full screen on mobile

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -31,8 +31,10 @@ a {
 }
 
 .row {
-	display: flex;
-	justify-content: center;
+	@media (min-width: $breakMobileLandscape) {
+		display: flex;
+		justify-content: center;
+	}
 }
 .row-inner {
 	min-width: 300px;


### PR DESCRIPTION
On small screens the width of the content varies with the width of the open feature's description.  Making the content stay full width at all times, whether there's an open item or not.