### PR TITLE
Add MSE info

### DIFF
--- a/features/mse.md
+++ b/features/mse.md
@@ -7,6 +7,7 @@ mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extension
 spec_url: https://w3c.github.io/media-source/
 spec_repo: https://github.com/w3c/media-source
 chrome_ref: 4563797888991232
+webkit_status: shipped
 ie_ref: Media Source Extensions
 ---
 

--- a/features/mse.md
+++ b/features/mse.md
@@ -1,0 +1,13 @@
+---
+title: Media Source Extensions
+category: multimedia
+firefox_status: 42
+bugzilla: 778617
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API
+spec_url: https://w3c.github.io/media-source/
+spec_repo: https://github.com/w3c/media-source
+chrome_ref: 4563797888991232
+ie_ref: Media Source Extensions
+---
+
+An API that allows creating media streams via JavaScript and play them using <audio> and <video> elements.


### PR DESCRIPTION
I've a few doubts.

- The feature is supported in IE11, but only on Windows 8+.
- Looks like it's supported on Safari 8, according to http://www.jwplayer.com/html5/mediasource/, but there's no info on https://www.webkit.org/status.html, https://www.chromestatus.com/features/4563797888991232 and https://dev.windows.com/en-us/microsoft-edge/platform/status/mediasourceextensions say Safari doesn't support it.
- Support for codecs varies according to browser and operating system.