### PR TITLE
Fix the browser functional test. Update IndexPage

### DIFF
--- a/tests/browserFunctional.js
+++ b/tests/browserFunctional.js
@@ -29,6 +29,9 @@ define(function(require) {
   // Within a test, `this` refers to a test suite object. You can use it
   // to skip the test or do other test-specific things.
   //
+  // `this.remote` is a `Command` object:
+  //    https://theintern.github.io/leadfoot/Command.html
+  //
   // `this.remote` is how we control the test browser for functional
   // tests. Instead of using it directly, we pass it to the constructors
   // for "page objects". We use those page objects to control the page
@@ -41,9 +44,9 @@ define(function(require) {
       bdd.it('should have correct title', function() {
         const page = new IndexPage(this.remote);
 
-        page.title.then(function(title) {
+        return page.title.then(function(title) {
           assert(title, 'title exists');
-          assert.equals(title, 'Firefox Platform Status');
+          assert.equal(title, 'Firefox Platform Status');
         });
       });
     });

--- a/tests/support/pages/main.js
+++ b/tests/support/pages/main.js
@@ -5,7 +5,7 @@ define(function() {
   // so we can provide the remote Command object
   // at runtime
   function IndexPage(remote) {
-    this.remote = remote;
+    this.remote = remote.get(require.toUrl('dist/index.html'));
   }
 
   IndexPage.prototype = {
@@ -13,8 +13,7 @@ define(function() {
 
     // Returns a promise that resolves to the title of the page
     get title() {
-      return this.remote
-        .getPageTitle();
+      return this.remote.getPageTitle();
     },
   };
 


### PR DESCRIPTION
The browser functional test was failing to return the Promise that it
created so the test was passing synchronously when it actually needs to
run asynchronously.

IndexPage needs to actually load the index.html page through Intern's
instrumenting HTTP server. This is done now.