### PR TITLE
Add Web Bluetooth API feature

### DIFF
--- a/features/web_bluetooth.md
+++ b/features/web_bluetooth.md
@@ -1,0 +1,13 @@
+---
+title: Web Bluetooth API
+category: apps
+bugzilla: 1204396
+firefox_status: in-development
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API
+spec_url: http://webbluetoothcg.github.io/web-bluetooth/
+spec_repo: https://github.com/WebBluetoothCG/web-bluetooth
+chrome_ref: 5264933985976320
+ie_ref: Web Bluetooth
+---
+
+An API for communicating with Bluetooth Low Energy devices as a GATT Client.


### PR DESCRIPTION
Following https://github.com/Rik/platform-status/pull/2, here's the Web Bluetooth API.