### PR TITLE
Basic search functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-uglify": "^1.4.2",
     "handlebars": "^4.0.3",
     "lodash.debounce": "^3.1.1",
+    "lunr": "^0.6.0",
     "markdown-it": "^5.0.0",
     "mkdirp": "^0.5.1",
     "mozilla-tabzilla": "^0.5.1",

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -114,13 +114,13 @@ article {
 .search {
 	text-align: center;
 	font-weight: normal;
-	margin: 1em 0;
+	margin: $gutterY 0;
 	@media (min-width: $breakMobileLandscape) {
 		display: flex;
 		align-items: center;
-		font-size: 1.5em;
+		font-size: $h3FontSize;
 		* + * {
-			margin-left: 1em;
+			margin-left: $gutterX;
 		}
 	}
 }
@@ -129,13 +129,13 @@ article {
 	font-weight: 300;
 	flex: 1;
 	width: 100%;
-	padding: 0 .5em;
+	padding: 0 $gutterX;
 	line-height: 1.7em;
 }
 .results-meta {
 	display: none;
 	background: #eee;
-	padding: .5em 1em;
+	padding: calc($gutterY / 2) $gutterX;
 }
 
 #features {
@@ -156,8 +156,8 @@ article {
 }
 
 .feature {
-	margin: 0 -1em;
-	padding: 0 1em;
+	margin: 0 -$gutterX;
+	padding: 0 $gutterX;
 	@media (min-width: $breakMobileLandscape) {
 		padding: calc($gutterY / 2) $gutterX;
 	}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -29,15 +29,18 @@ a {
 }
 
 .row {
-	display: flex;
+	display: block;
 	@media (min-width: $breakDesktop) {
-		display: flex;
+		display: block;
 		justify-content: center;
 	}
 }
 .row-inner {
 	min-width: 300px;
 	max-width: 1020px;
+	margin: 0 auto;
+	flex: 1;
+	padding: calc($gutterY / 2) $gutterX;
 }
 header {
 	background: $developerBlueVibrant;
@@ -108,16 +111,53 @@ article {
 	background-color: #fff;
 }
 
+.search {
+	text-align: center;
+	font-weight: normal;
+	margin: 1em 0;
+	@media (min-width: $breakMobileLandscape) {
+		display: flex;
+		align-items: center;
+		font-size: 1.5em;
+		* + * {
+			margin-left: 1em;
+		}
+	}
+}
+.search-input {
+	font: inherit;
+	font-weight: 300;
+	flex: 1;
+	width: 100%;
+	padding: 0 .5em;
+	line-height: 1.7em;
+}
+.results-meta {
+	display: none;
+	background: #eee;
+	padding: .5em 1em;
+}
+
 #features {
 	list-style: none;
 	margin: calc($gutterY / 2) 0;
 	padding: 0;
 }
 
+#features.searched {
+	display: flex;
+	flex-direction: column;
+}
+#features.searched .feature {
+	display: none;
+}
+#features.searched .feature.match {
+	display: block;
+}
+
 .feature {
-	margin: 0;
-	padding: 0;
-	padding-left: $gutterX;
+	margin: 0 -1em;
+	padding: 0 1em;
 	@media (min-width: $breakMobileLandscape) {
 		padding: calc($gutterY / 2) $gutterX;
 	}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-var search = require('./search');
+import search from './search';
 
 if ('serviceWorker' in navigator) {
   const started = Date.now();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,5 @@
+var search = require('./search');
+
 if ('serviceWorker' in navigator) {
   const started = Date.now();
   let shouldUpdate = true;
@@ -51,3 +53,79 @@ if ('serviceWorker' in navigator) {
       didUpdate();
     });
 }
+
+search.initialize().then((index) => {
+  const queryEl = document.querySelector('.search-input');
+  const featureEls = Array.prototype.slice.call(document.querySelectorAll('.feature'));
+  const featureListEl = document.querySelector('#features');
+  const clearEl = document.querySelector('.search-clear');
+  const resultMetaEl = document.querySelector('.results-meta');
+  const resultCountEl = document.querySelector('.search-results-count');
+
+  // debounce events
+  var searchTimeout;
+  function triggerSearch() {
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(performSearch, 100);
+  }
+
+  queryEl.addEventListener('change', triggerSearch);
+  queryEl.addEventListener('input', triggerSearch);
+  queryEl.addEventListener('keypress', triggerSearch);
+
+  clearEl.addEventListener('click', function (e) {
+    e.preventDefault();
+    queryEl.value = '';
+    performSearch();
+    queryEl.focus();
+  });
+
+  // If the user has entered a query before the index is ready, do a search now
+  if (queryEl.value) {
+    performSearch();
+  }
+
+  function performSearch() {
+    var query = queryEl.value;
+
+    featureEls.forEach(function (el) {
+      el.classList.remove('match');
+      el.style.order = null;
+    });
+
+    if (query) {
+      var results = index.search(query);
+      resultsMeta(results.length);
+      if (results.length) {
+        results.forEach(function (result, i) {
+          var el = document.getElementById(result.ref);
+          el.classList.add('match');
+          el.style.order = i;
+        });
+      }
+      featureListEl.classList.add('searched');
+    } else {
+      resultsMeta();
+      featureListEl.classList.remove('searched');
+    }
+  }
+
+  function resultsMeta(n) {
+    if (n === undefined) {
+      resultMetaEl.style.display = 'none';
+      return;
+    }
+    resultMetaEl.style.display = 'block';
+    if (n === 0) {
+      resultCountEl.innerHTML = 'No results.';
+    }
+    if (n === 1) {
+      resultCountEl.innerHTML = 'Showing one result.';
+    }
+    if (n > 1) {
+      resultCountEl.innerHTML = 'Showing ' + n + ' results.';
+    }
+  }
+}).catch(function (err) {
+  console.error(err);
+});

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,0 +1,55 @@
+import lunr from 'lunr';
+
+function loadFeatureData(cb) {
+  return new Promise(function (resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('get', 'status.json');
+    xhr.addEventListener('load', function () {
+      resolve(this.responseText);
+    });
+    xhr.addEventListener('error', function () {
+      reject('failed to load feature data');
+    });
+    xhr.send();
+  });
+}
+
+function parseFeatureData(body) {
+  return JSON.parse(body);
+}
+
+function buildSearchIndex(data) {
+
+  // index schema
+  var searchIndex = lunr(function () {
+    this.field('title', { boost: 100 });
+    this.field('slug', { boost: 100 });
+    this.field('summary', { boost: 10 });
+    this.field('category', { boost: 1 });
+
+    this.ref('slug');
+  });
+
+  searchIndex.pipeline.remove(lunr.stopWordFilter);
+
+  // ingest documents
+  var features = data.features;
+  for (var i = 0; i < data.features.length; i++) {
+    var doc = data.features[i];
+    // quick n dirty html strip. not for security.
+    doc.summary = doc.summary.replace(/<[^>]+>/g, '');
+    searchIndex.add(doc);
+  }
+
+  return searchIndex;
+}
+
+function initialize() {
+  return loadFeatureData()
+          .then(parseFeatureData)
+          .then(buildSearchIndex);
+}
+
+export default {
+  initialize: initialize
+};

--- a/src/tpl/index.html
+++ b/src/tpl/index.html
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="bundle.css" inline>
 </head>
 <body>
-  <header class="row">
+  <header class="row header">
     <div class="row-inner">
       <div id="tabzilla">
         <a href="https://www.mozilla.org/">Mozilla</a>
@@ -53,62 +53,69 @@
     </header>
   </header>
   <article class="row">
-    <ul class="row-inner" id="features">
-      {{#each features}}
-        <li class="feature" id="{{slug}}" tabindex="0">
-          <a href="#{{slug}}"><i aria-hidden="true" class="feature-anchor"></i></a>
-          <div class="feature-header">
-            <h3 class="feature-title">{{title}}</h3>
-            <div class="feature-status">
-              <ul>
-                {{> browserStatus browser="chrome" url=chrome_url status=chrome_status footnote=chrome_footnote}}
-                {{> browserStatus browser="opera" url=opera_url status=opera_status footnote=opera_footnote}}
-                {{> browserStatus browser="webkit" url=webkit_url status=webkit_status footnote=webkit_footnote}}
-                {{> browserStatus browser="edge" url=ie_url status=ie_status footnote=edge_footnote}}
-                {{> browserStatus browser="firefox" status=firefox_status version=firefox_version url_slug=slug channel=firefox_channel}}
-              </ul>
+    <div class="row-inner">
+      <div class="search">
+        <label for="query">Search features</label>
+        <input type="text" id="query" class="search-input" placeholder="Feature or Keyword" tabindex="1"></label>
+      </div>
+      <div class="results-meta"><span class="search-results-count"></span> <a role="button" href="#" class="search-clear">clear search</a></div>
+      <ul id="features">
+        {{#each features}}
+          <li class="feature" id="{{slug}}" tabindex="0">
+            <a href="#{{slug}}"><i aria-hidden="true" class="feature-anchor"></i></a>
+            <div class="feature-header">
+              <h3 class="feature-title">{{title}}</h3>
+              <div class="feature-status">
+                <ul>
+                  {{> browserStatus browser="chrome" url=chrome_url status=chrome_status footnote=chrome_footnote}}
+                  {{> browserStatus browser="opera" url=opera_url status=opera_status footnote=opera_footnote}}
+                  {{> browserStatus browser="webkit" url=webkit_url status=webkit_status footnote=webkit_footnote}}
+                  {{> browserStatus browser="edge" url=ie_url status=ie_status footnote=edge_footnote}}
+                  {{> browserStatus browser="firefox" status=firefox_status version=firefox_version url_slug=slug channel=firefox_channel}}
+                </ul>
+              </div>
             </div>
-          </div>
-          <div class="feature-meta">
-            <div class="feature-links">
-              <ul>
-              {{#if mdn_url}}
-                <li>
-                  <a target="_blank" href="{{mdn_url}}" title="Documentation on Mozilla Developer Network (MDN)">
-                    <i aria-hidden="true" class="icon icon-mdn"></i>Docs
-                  </a>
-                </li>
-              {{/if}}
-              {{#if spec_url}}
-                <li>
-                  <a target="_blank" href="{{spec_url}}" title="{{alt spec_status 'spec' 'long'}}">
-                    <i aria-hidden="true" class="icon icon-spec"></i>{{alt spec_status 'spec' 'short'}}
-                  </a>
-                </li>
-              {{/if}}
-              {{#if caniuse_ref}}
-                <li>
-                  <a target="_blank" href="http://caniuse.com/#feat={{caniuse_ref}}" title="Global browser support: {{caniuse_usage_perc_y}}% full, {{caniuse_usage_perc_a}}% partial">
-                    <i aria-hidden="true" class="icon icon-caniuse"></i>Can I use {{caniuse_usage_perc_total}}%
-                  </a>
-                </li>
-              {{/if}}
-              {{#if bugzilla}}
-                <li class="link-bug">
-                  <a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bugzilla}}" title="Implementation bug at bugzilla.mozilla.org">
-                    <i aria-hidden="true" class="icon icon-bugzilla"></i>{{#if_eq firefox_status "shipped"}}Complete
-                    {{else}}{{bugzilla_resolved_count}}/{{bugzilla_dependant_count}} Resolved
-                    {{/if_eq}}
-                  </a>
-                </li>
-              {{/if}}
-              </ul>
+            <div class="feature-meta">
+              <div class="feature-links">
+                <ul>
+                {{#if mdn_url}}
+                  <li>
+                    <a target="_blank" href="{{mdn_url}}" title="Documentation on Mozilla Developer Network (MDN)">
+                      <i aria-hidden="true" class="icon icon-mdn"></i>Docs
+                    </a>
+                  </li>
+                {{/if}}
+                {{#if spec_url}}
+                  <li>
+                    <a target="_blank" href="{{spec_url}}" title="{{alt spec_status 'spec' 'long'}}">
+                      <i aria-hidden="true" class="icon icon-spec"></i>{{alt spec_status 'spec' 'short'}}
+                    </a>
+                  </li>
+                {{/if}}
+                {{#if caniuse_ref}}
+                  <li>
+                    <a target="_blank" href="http://caniuse.com/#feat={{caniuse_ref}}" title="Global browser support: {{caniuse_usage_perc_y}}% full, {{caniuse_usage_perc_a}}% partial">
+                      <i aria-hidden="true" class="icon icon-caniuse"></i>Can I use {{caniuse_usage_perc_total}}%
+                    </a>
+                  </li>
+                {{/if}}
+                {{#if bugzilla}}
+                  <li class="link-bug">
+                    <a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bugzilla}}" title="Implementation bug at bugzilla.mozilla.org">
+                      <i aria-hidden="true" class="icon icon-bugzilla"></i>{{#if_eq firefox_status "shipped"}}Complete
+                      {{else}}{{bugzilla_resolved_count}}/{{bugzilla_dependant_count}} Resolved
+                      {{/if_eq}}
+                    </a>
+                  </li>
+                {{/if}}
+                </ul>
+              </div>
+              <p class="feature-summary">{{{summary}}}</p>
             </div>
-            <p class="feature-summary">{{{summary}}}</p>
-          </div>
-        </li>
-      {{/each}}
-    </ul>
+          </li>
+        {{/each}}
+      </ul>
+    </div>
   </article>
   <footer class="row">
     <div class="row-inner">


### PR DESCRIPTION
Basic search functionality with lunr is available on this branch. This is as-of-yet a work-in-progress and point of discussion for the overall search feature.

Breakdown of the search feature as I see it in my mind

- [x] Import `lunr` library
- [x] Basic search (features show/hide based on live typing)
- [x] Search styling (open questions about appearance)
- [x] "Clear Search" button/link
- [x] Result ranking by relevance (right now alpha order is preserved)
- [ ] Tests!

Big questions are around styling. The `#features` element is only as big as its widest visible child's intrinsic width. This means as you search the column randomly resizes. Is this intended or can we set the width on the list?

We could potentially use flexbox for the features list. This would allow for purely style-based re-ordering of results using the `order` property. Might have layout perf implications, need to investigate.

Would appreciate an initial code once-through and thoughts on the direction!

This will resolve #129.