### PR TITLE
Rename wasm.js to WebAssembly.

### DIFF
--- a/features/web-assembly.md
+++ b/features/web-assembly.md
@@ -1,5 +1,5 @@
 ---
-title: wasm.js
+title: WebAssembly (WASM)
 category: apps, games
 firefox_status: in-development
 bugzilla: 1188259


### PR DESCRIPTION
wasm.js isn't a thing