### PR TITLE
Update file-exists to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint": "^1.6.0",
     "eslint-config-airbnb": "^0.1.0",
     "express": "^4.13.3",
-    "file-exists": "^0.1.1",
+    "file-exists": "^1.0.0",
     "glob": "^6.0.1",
     "gray-matter": "^2.0.1",
     "gulp": "^3.9.0",


### PR DESCRIPTION
file-exists v1.0.0 doesn't use deprecated `fs` functions anymore.