### PR TITLE
Add caniuse global usage percentages.

### DIFF
--- a/engine/canIUseParser.js
+++ b/engine/canIUseParser.js
@@ -1,0 +1,17 @@
+import cache from './cache.js';
+
+export default class CanIUseParser {
+  results = {}
+  url = 'https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json';
+
+  majorVersion(version) {
+    return parseInt(version.substr(0, version.indexOf('.')), 10);
+  }
+
+  read(options) {
+    cache.readJson(this.url, options.cacheDir)
+      .then((results) => {
+        this.results = results;
+      });
+  }
+}


### PR DESCRIPTION
Partially fixes #36, we'll still need to add it to the UI somewhere.