### PR TITLE
Set Permissions API as in development in Firefox, since it isn't going to ship anytime soon

### DIFF
--- a/features/permissions.md
+++ b/features/permissions.md
@@ -2,7 +2,7 @@
 title: Permissions API
 category: apps
 bugzilla: 1105827
-firefox_status: 45
+firefox_status: in-development
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API
 spec_url: https://w3c.github.io/permissions/
 spec_repo: https://github.com/w3c/permissions


### PR DESCRIPTION
It hasn't shipped in 45 and will not ship until https://bugzilla.mozilla.org/show_bug.cgi?id=1221106 is resolved.
Instead of changing firefox_status to 46, and then change it again if it doesn't get shipped, I think it's better to set it as "in-development".