### PR TITLE
Update Firefox status of the Permission API

### DIFF
--- a/features/permissions.md
+++ b/features/permissions.md
@@ -2,7 +2,7 @@
 title: Permissions API
 category: apps
 bugzilla: 1105827
-firefox_status: in-development
+firefox_status: 46
 mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API
 spec_url: https://w3c.github.io/permissions/
 spec_repo: https://github.com/w3c/permissions


### PR DESCRIPTION
It's going to be enabled by default in Firefox 46: https://bugzilla.mozilla.org/show_bug.cgi?id=1221106