### PR TITLE
Add Web Speech Synthesis API.  Fixes #243

### DIFF
--- a/features/webspeech-synthesis.md
+++ b/features/webspeech-synthesis.md
@@ -1,0 +1,15 @@
+---
+title: Web Speech Synthesis
+category: api
+bugzilla: 1003439
+firefox_status: 45
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API#Speech_synthesis
+spec_url: https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html
+spec_repo: https://dvcs.w3.org/hg/speech-api/
+caniuse_ref: speech-synthesis
+webkit_ref: shipped
+chrome_ref: 4782875580825600
+ie_ref: webspeechapisynthesis
+---
+
+Javascript API to generate text-to-speech output in web applications.


### PR DESCRIPTION
Add Web Speech Synthesis API that turned on Firefox Desktop 45.  Edge and Chrome status already have this entry.