### PR TITLE
Show 'Complete' if the tracking bug is resolved

### DIFF
--- a/src/tpl/index.html
+++ b/src/tpl/index.html
@@ -103,6 +103,7 @@
                   <li class="link-bug">
                     <a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bugzilla}}" title="Implementation bug at bugzilla.mozilla.org">
                       <i aria-hidden="true" class="icon icon-bugzilla"></i>{{#if_eq firefox_status "shipped"}}Complete
+                      {{else if_eq bugzilla_status "RESOLVED"}}Complete
                       {{else}}{{bugzilla_resolved_count}}/{{bugzilla_dependant_count}} Resolved
                       {{/if_eq}}
                     </a>


### PR DESCRIPTION
Sometimes a feature tracked by a bug is complete and the bug gets resolved, but some of the bugs it depends on remain open because deemed unnecessary to release the feature.