### PR TITLE
Explicitly install babel-preset-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "babel-core": "^6.2.1",
     "babel-eslint": "^4.1.6",
+    "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-0": "^6.1.18",
     "babelify": "^7.2.0",


### PR DESCRIPTION
```
npm WARN peerDependencies The peer dependency babel-preset-es2015@* included from babel-preset-es2015-loose will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

Fixes #273.