### PR TITLE
Fixed layout issue on Safari

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -7,7 +7,6 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	height: 100%;
 }
 
 @import '../../node_modules/mozilla-tabzilla/css/tabzilla.css';


### PR DESCRIPTION
Due to the flexbox context on body, header and footer are bad positionnly. 

Body is in a flexbox's context , it has a height of 100% and html too. This causes a layout bug in Safari (mobile and desktop). Value 100% for height of html and body is useless, by deleting this rule, the bug is fixed

See the issue on webcompat https://webcompat.com/issues/2187 (for screenshot)