### PR TITLE
Update SharedArrayBuffer status

### DIFF
--- a/features/shared_array_buffer.md
+++ b/features/shared_array_buffer.md
@@ -2,8 +2,9 @@
 title: Shared Array Buffers
 category: apps, games
 bugzilla: 1225406
-firefox_status: 45
-spec_url: https://github.com/lars-t-hansen/ecmascript_sharedmem
+firefox_status: 46
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
+spec_url: http://lars-t-hansen.github.io/ecmascript_sharedmem/shmem.html
 spec_repo: https://github.com/lars-t-hansen/ecmascript_sharedmem
 chrome_ref: 4570991992766464
 ---


### PR DESCRIPTION
* This will only be in 46, see https://bugzilla.mozilla.org/show_bug.cgi?id=1225406#c3
* spec_url is this http://lars-t-hansen.github.io/ecmascript_sharedmem/shmem.html
* Still preffed off, but can't add a note for this (see issue #283 )
* Added MDN docs :)