### PR TITLE
eslint for src/js/index.js and cleanup

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -47,7 +47,7 @@ gulp.task('clean', () => del([distDir]));
 
 gulp.task('lint', () =>
   gulp
-  .src(['./*.js', './engine/*.js', './src/*.js', './tests/**/*.js'])
+  .src(['./*.js', './engine/*.js', './src/js/*.js', './tests/**/*.js'])
   .pipe(plugins.eslint())
   .pipe(plugins.eslint.format())
   .pipe(plugins.eslint.failOnError())

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -135,11 +135,6 @@ article {
 	padding: 0 $gutterX;
 	line-height: 1.7em;
 }
-.results-meta {
-	display: none;
-	background: #eee;
-	padding: calc($gutterY / 2) $gutterX;
-}
 
 #features {
 	list-style: none;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,7 +9,7 @@ search().then((index) => {
   const queryEl = document.querySelector('.search-input');
   const featureListEl = document.querySelector('#features');
 
-  function clearMatches(references) {
+  function clearMatches(references = []) {
     Array.from(document.querySelectorAll('.feature.match')).forEach((el) => {
       if (references.indexOf(el.id) === -1) {
         el.classList.remove('match');
@@ -37,8 +37,8 @@ search().then((index) => {
     }
   }
 
-  const debounceSearch = debounce(performSearch, 150, {
-    maxWait: 750,
+  const debounceSearch = debounce(performSearch, 250, {
+    maxWait: 1000,
   });
   queryEl.addEventListener('change', debounceSearch);
   queryEl.addEventListener('input', debounceSearch);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,138 +1,61 @@
+/* global ga */
 import search from './search';
+import refreshOnUpdate from './refresh-on-update';
+import debounce from 'lodash.debounce';
 
-if ('serviceWorker' in navigator) {
-  const started = Date.now();
-  let shouldUpdate = true;
-  function didUpdate() {
-    if (!shouldUpdate) {
-      return;
-    }
-    shouldUpdate = false;
-    // Only show the prompt if there is currently a controller
-    // so it is not shown on first load.
-    if (!navigator.serviceWorker.controller) {
-      return;
-    }
-    if (Date.now() - started < 5000) {
-      console.log('Reloading to activate updated worker.');
-      location.reload();
-    } else {
-      console.log('Not reloading, loaded too long..');
-    }
-  }
-  if (navigator.serviceWorker.controller) {
-    navigator.serviceWorker.controller.addEventListener('statechange', ({target}) => {
-      console.log('sw.controller.onstatechange "%s"', target.state);
-      if (target.state === 'redundant') {
-        didUpdate();
-      }
-    });
-  }
+refreshOnUpdate();
 
-  navigator.serviceWorker.register('offline-worker.js')
-    .then((registration) => {
-      console.log('offline-worker.js registered');
-      return new Promise((resolve) => {
-        registration.addEventListener('updatefound', resolve);
-      });
-    })
-    .then(({target}) => {
-      const {installing} = target;
-      console.log('registration.onupdatefound');
-      // Wait for the new service worker to be installed before
-      // prompting to update.
-      return new Promise((resolve) => {
-        installing.addEventListener('statechange', resolve);
-      });
-    })
-    .then(({target}) => {
-      console.log('registration.installing.onstatechange state "%s"', target.state);
-      if (target.state !== 'installed') {
-        return;
-      }
-      didUpdate();
-    });
-}
-
-search.initialize().then((index) => {
+search().then((index) => {
   const queryEl = document.querySelector('.search-input');
-  const featureEls = Array.prototype.slice.call(document.querySelectorAll('.feature'));
   const featureListEl = document.querySelector('#features');
-  const clearEl = document.querySelector('.search-clear');
-  const resultMetaEl = document.querySelector('.results-meta');
-  const resultCountEl = document.querySelector('.search-results-count');
 
-  // debounce events
-  var searchTimeout;
-  function triggerSearch() {
-    clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(performSearch, 100);
-  }
-
-  queryEl.addEventListener('change', triggerSearch);
-  queryEl.addEventListener('input', triggerSearch);
-  queryEl.addEventListener('keypress', triggerSearch);
-
-  clearEl.addEventListener('click', function (e) {
-    e.preventDefault();
-    queryEl.value = '';
-    performSearch();
-    queryEl.focus();
-  });
-
-  // If the user has entered a query before the index is ready, do a search now
-  if (queryEl.value) {
-    performSearch();
+  function clearMatches(references) {
+    Array.from(document.querySelectorAll('.feature.match')).forEach((el) => {
+      if (references.indexOf(el.id) === -1) {
+        el.classList.remove('match');
+        el.style.order = null;
+      }
+    });
   }
 
   function performSearch() {
-    var query = queryEl.value;
-
-    featureEls.forEach(function (el) {
-      el.classList.remove('match');
-      el.style.order = null;
-    });
-
+    const query = queryEl.value;
     if (query) {
-      var results = index.search(query);
-      resultsMeta(results.length);
+      const results = index.search(query).map(result => result.ref);
+      clearMatches(results);
       if (results.length) {
-        results.forEach(function (result, i) {
-          var el = document.getElementById(result.ref);
+        results.forEach((result, i) => {
+          const el = document.getElementById(result);
           el.classList.add('match');
           el.style.order = i;
         });
       }
       featureListEl.classList.add('searched');
     } else {
-      resultsMeta();
+      clearMatches();
       featureListEl.classList.remove('searched');
     }
   }
 
-  function resultsMeta(n) {
-    if (n === undefined) {
-      resultMetaEl.style.display = 'none';
-      return;
-    }
-    resultMetaEl.style.display = 'block';
-    if (n === 0) {
-      resultCountEl.innerHTML = 'No results.';
-    }
-    if (n === 1) {
-      resultCountEl.innerHTML = 'Showing one result.';
-    }
-    if (n > 1) {
-      resultCountEl.innerHTML = 'Showing ' + n + ' results.';
-    }
+  const debounceSearch = debounce(performSearch, 150, {
+    maxWait: 750,
+  });
+  queryEl.addEventListener('change', debounceSearch);
+  queryEl.addEventListener('input', debounceSearch);
+  queryEl.addEventListener('keypress', debounceSearch);
+
+  // If the user has entered a query before the index is ready, do a search now
+  if (queryEl.value) {
+    performSearch();
   }
-}).catch(function (err) {
+}).catch((err) => {
   console.error(err);
 });
 
-window.ga = window.ga || function() {
+window.ga = window.ga || function ga() {
   (ga.q = ga.q || []).push(arguments);
-}
-ga.l = +new Date;
+};
+ga.l = Date.now();
+
 ga('create', 'UA-49796218-38', 'auto');
 ga('send', 'pageview');

--- a/src/js/refresh-on-update.js
+++ b/src/js/refresh-on-update.js
@@ -1,0 +1,57 @@
+const started = Date.now();
+let shouldUpdate = true;
+function didUpdate() {
+  if (!shouldUpdate) {
+    return;
+  }
+  shouldUpdate = false;
+  // Only show the prompt if there is currently a controller
+  // so it is not shown on first load.
+  if (!navigator.serviceWorker.controller) {
+    return;
+  }
+  if (Date.now() - started < 5000) {
+    console.log('Reloading to activate updated worker.');
+    location.reload();
+  } else {
+    console.log('Not reloading, loaded too long.');
+  }
+}
+
+export default function initialize() {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+  const { controller } = navigator.serviceWorker;
+  if (controller) {
+    controller.addEventListener('statechange', ({ target }) => {
+      if (target.state === 'redundant') {
+        didUpdate();
+      }
+    });
+  }
+
+  navigator.serviceWorker.register('offline-worker.js')
+    .then((registration) => {
+      console.log('offline-worker.js registered');
+      return new Promise((resolve) => {
+        registration.addEventListener('updatefound', resolve);
+      });
+    })
+    .then(({ target }) => {
+      const { installing } = target;
+      // console.log('registration.onupdatefound');
+      // Wait for the new service worker to be installed before
+      // prompting to update.
+      return new Promise((resolve) => {
+        installing.addEventListener('statechange', resolve);
+      });
+    })
+    .then(({ target }) => {
+      // console.log('registration.installing.onstatechange state "%s"', target.state);
+      if (target.state !== 'installed') {
+        return;
+      }
+      didUpdate();
+    });
+}

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,13 +1,13 @@
 import lunr from 'lunr';
 
-function loadFeatureData(cb) {
-  return new Promise(function (resolve, reject) {
-    var xhr = new XMLHttpRequest();
+function loadFeatureData() {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
     xhr.open('get', 'status.json');
-    xhr.addEventListener('load', function () {
+    xhr.addEventListener('load', () => {
       resolve(this.responseText);
     });
-    xhr.addEventListener('error', function () {
+    xhr.addEventListener('error', () => {
       reject('failed to load feature data');
     });
     xhr.send();
@@ -19,37 +19,29 @@ function parseFeatureData(body) {
 }
 
 function buildSearchIndex(data) {
-
   // index schema
-  var searchIndex = lunr(function () {
+  const searchIndex = lunr(() => {
     this.field('title', { boost: 100 });
     this.field('slug', { boost: 100 });
     this.field('summary', { boost: 10 });
     this.field('category', { boost: 1 });
-
     this.ref('slug');
   });
 
   searchIndex.pipeline.remove(lunr.stopWordFilter);
 
   // ingest documents
-  var features = data.features;
-  for (var i = 0; i < data.features.length; i++) {
-    var doc = data.features[i];
+  data.features.forEach((doc) => {
     // quick n dirty html strip. not for security.
     doc.summary = doc.summary.replace(/<[^>]+>/g, '');
     searchIndex.add(doc);
-  }
+  });
 
   return searchIndex;
 }
 
-function initialize() {
+export default function initialize() {
   return loadFeatureData()
-          .then(parseFeatureData)
-          .then(buildSearchIndex);
+    .then(parseFeatureData)
+    .then(buildSearchIndex);
 }
-
-export default {
-  initialize: initialize
-};

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -4,8 +4,8 @@ function loadFeatureData() {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open('get', 'status.json');
-    xhr.addEventListener('load', () => {
-      resolve(this.responseText);
+    xhr.addEventListener('load', ({ target }) => {
+      resolve(target.responseText);
     });
     xhr.addEventListener('error', () => {
       reject('failed to load feature data');
@@ -20,7 +20,7 @@ function parseFeatureData(body) {
 
 function buildSearchIndex(data) {
   // index schema
-  const searchIndex = lunr(() => {
+  const searchIndex = lunr(function didLoad() {
     this.field('title', { boost: 100 });
     this.field('slug', { boost: 100 });
     this.field('summary', { boost: 10 });

--- a/src/tpl/index.html
+++ b/src/tpl/index.html
@@ -50,9 +50,8 @@
     <div class="row-inner">
       <div class="search">
         <label for="query">Search features</label>
-        <input type="text" id="query" class="search-input" placeholder="Feature or Keyword" tabindex="1"></label>
+        <input type="search" id="query" class="search-input" placeholder="Feature or Keyword" tabindex="1"></label>
       </div>
-      <div class="results-meta"><span class="search-results-count"></span> <a role="button" href="#" class="search-clear">clear search</a></div>
       <ul id="features">
         {{#each features}}
           <li class="feature" id="{{slug}}" tabindex="0">


### PR DESCRIPTION
eslint didn't include the client js.

- sw based refresh is now factored out into its own file
- search is now using ES6
  - using debounce for input
  - keeping less references to DOM elements
  - simplified: removed search meta element that took space only for telling the user how many entries he is looking at