### PR TITLE
Directly use badge from Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Platatus
 
-[![Build Status](https://img.shields.io/travis/mozilla/platatus.svg?branch=master)](https://travis-ci.org/mozilla/platatus)
+[![Build Status](https://api.travis-ci.org/mozilla/platatus.svg?branch=master)](https://travis-ci.org/mozilla/platatus)
 [![dependencies](https://img.shields.io/david/mozilla/platatus.svg)](https://david-dm.org/mozilla/platatus)
 [![devdependencies](https://img.shields.io/david/dev/mozilla/platatus.svg)](https://david-dm.org/mozilla/platatus#info=devDependencies)
 


### PR DESCRIPTION
The shields.io URL was wrong (https://img.shields.io/travis/mozilla/platatus.svg?branch=master should have been https://img.shields.io/travis/mozilla/platatus/master.svg), but, since Travis CI adheres to the Shields standard, we can directly use its image.