### PR TITLE
Pin to Eslint 2.2.0 until 'estraverse-fb' bug is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compression": "^1.6.0",
     "css-mqpacker": "^4.0.0",
     "del": "^2.0.2",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-config-airbnb": "^6.0.1",
     "eslint-plugin-react": "^4.0.0",
     "express": "^4.13.3",


### PR DESCRIPTION
Until https://github.com/eslint/eslint/issues/5476 is fixed, we need to use 2.2.0.