### PR TITLE
Wait for the caniuse data and the firefox version to be downloaded before using them

### DIFF
--- a/engine/canIUseParser.js
+++ b/engine/canIUseParser.js
@@ -9,7 +9,7 @@ export default class CanIUseParser {
   }
 
   read(options) {
-    cache.readJson(this.url, options.cacheDir)
+    return cache.readJson(this.url, options.cacheDir)
       .then((results) => {
         this.results = results;
       });

--- a/engine/firefoxVersionParser.js
+++ b/engine/firefoxVersionParser.js
@@ -9,7 +9,7 @@ export default class FirefoxVersionParser {
   }
 
   read(options) {
-    cache.readJson(this.url, options.cacheDir)
+    return cache.readJson(this.url, options.cacheDir)
       .then((results) => {
         this.results = {
           stable: this.majorVersion(results.LATEST_FIREFOX_VERSION),


### PR DESCRIPTION
Right now we're not waiting, so if you don't have the data cached (e.g. you're doing a build from scratch), the build is likely to fail.