### PR TITLE
Corrected status of 'backdrop-filter' CSS property

### DIFF
--- a/features/css-backdrop-filter.md
+++ b/features/css-backdrop-filter.md
@@ -1,8 +1,8 @@
 ---
 title: CSS backdrop-filter (subset of Filter FX L2)
 category: css, layout
-bugzilla: 1178765
-firefox_status: under-consideration
+bugzilla: 1578503
+firefox_status: in-development
 mdn_url: https://developer.mozilla.org/docs/Web/CSS/backdrop-filter
 spec_url: https://dev.w3.org/fxtf/filters-2/#BackdropFilterPropert
 caniuse_ref: css-backdrop-filter


### PR DESCRIPTION
The CSS property `backdrop-filter` already got implemented, though it didn't get enabled by default yet due to some remaining issues. Therefore I've changed the bug ID to the one for letting the feature ride the trains.

Furthermore I've corrected the status of the feature.

Sebastian