### PR TITLE
Added 'size-adjust' descriptor for @font-face rules

### DIFF
--- a/features/css-size-adjust-descriptor.md
+++ b/features/css-size-adjust-descriptor.md
@@ -1,0 +1,9 @@
+---
+title: CSS size-adjust descriptor for @font-face rules
+category: css, layout
+bugzilla: 1698495
+firefox_status: in-development
+spec_url: https://drafts.csswg.org/css-fonts-5/#size-adjust-desc
+---
+
+Allow to adjust the scaling of individual fonts loaded using @font-face, to better harmonize the visual sizes of different designs, or to more closely match a fallback face to a resource that may be swapped in later, thereby minimizing visual layout shift when the final font becomes available.


### PR DESCRIPTION
Jonathan Kew sent an [intent to prototype the `glyph-scale-factor` descriptor for `@font-face` rules a few days ago](https://groups.google.com/g/mozilla.dev.platform/c/joBc4SoTOPc).

In the meantime, the [name of it got changed to `size-adjust`](https://github.com/w3c/csswg-drafts/pull/6108), though.

This patch adds this descriptor including Jonathan's description for it.

Sebastian