### PR TITLE
Added AVIF

### DIFF
--- a/features/avif.md
+++ b/features/avif.md
@@ -1,0 +1,13 @@
+---
+title: AV1 Still Image File Format (AVIF)
+category: media
+bugzilla: 1682995
+firefox_status: in-development
+mdn_url: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#avif
+spec_url: https://aomediacodec.github.io/av1-avif/
+caniuse_ref: avif
+chrome_ref: 4905307790639104
+webkit_status: in-development
+---
+
+AVIF is an image format based on the AV1 video codec created by the Alliance for Open Media.


### PR DESCRIPTION
This adds the AV1 Still Image File Format (AVIF).

Jon Bauman sent an [intent to ship AVIF](https://groups.google.com/g/mozilla.dev.platform/c/eWIa9XXxHsc) lately, so I thought it should be listed as a platform status entry.

According to https://www.chromestatus.com/features/4905307790639104 Chrome already shipped this a while ago.
WebKit doesn't have an entry on its feature status page, though they are obviously also working on it right now according to https://bugs.webkit.org/show_bug.cgi?id=207750.
The Chrome Platform Status page also claims that Edge is positive on supporting it. But I assume with the switch to Chromium Edge should automatically have support for it now. I didn't test it, though, and therefore didn't add a hint for it.

Sebastian